### PR TITLE
Purescript 0.9.1 update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,13 +15,14 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-exceptions": "~0.3.3",
-    "purescript-maps": "~0.5.4",
-    "purescript-maybe": "~0.3.5",
-    "purescript-node-fs": "~0.11.0",
-    "purescript-node-streams": "~0.4.0",
-    "purescript-posix-types": "~0.1.1",
-    "purescript-unsafe-coerce": "~0.1.0"
+    "purescript-console": "^1.0.0",
+    "purescript-exceptions": "^1.0.0",
+    "purescript-maps": "^1.0.0",
+    "purescript-maybe": "^1.0.0",
+    "purescript-node-fs": "^1.0.0",
+    "purescript-node-streams": "^1.0.0",
+    "purescript-posix-types": "^1.0.0",
+    "purescript-unsafe-coerce": "^1.0.0",
+    "purescript-partial": "^1.1.2"
   }
 }

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -24,11 +24,11 @@ module Node.Process
   ) where
 
 import Prelude
-import Control.Monad.Eff
+import Partial.Unsafe (unsafePartial)
+import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Exception (EXCEPTION())
-import Data.Maybe (Maybe())
-import Data.Maybe.Unsafe (fromJust)
+import Data.Maybe (Maybe(), fromJust)
 import Data.StrMap (StrMap())
 import Data.StrMap as StrMap
 import Data.Posix (Pid())
@@ -111,7 +111,7 @@ pid :: Pid
 pid = process.pid
 
 platform :: Platform
-platform = fromJust (Platform.fromString process.platform)
+platform = unsafePartial $ fromJust (Platform.fromString process.platform)
 
 -- | Cause the process to exit with the supplied integer code. An exit code
 -- | of 0 is normally considered successful, and anything else is considered a


### PR DESCRIPTION
There's a debatable change at https://github.com/purescript-node/purescript-node-process/compare/master...kika:purescript-0.9.1?expand=1#diff-384f7e929f378f4221c49e930dfcd89eR114

I went with less API-intrusive choice just removing the partiality constraint, but may be it's worth the effort to change `platform` to return `Maybe Platform`?

Fixes #3