### PR TITLE
Make Node.Process.platform safe

### DIFF
--- a/src/Node/Platform.purs
+++ b/src/Node/Platform.purs
@@ -5,39 +5,49 @@ module Node.Platform where
 import Prelude
 import Data.Maybe (Maybe(..))
 
+-- | See [the Node docs](https://nodejs.org/dist/latest-v6.x/docs/api/os.html#os_os_platform).
 data Platform
-  = Darwin
+  = AIX
+  | Darwin
   | FreeBSD
-  | OpenBSD
   | Linux
+  | OpenBSD
   | SunOS
   | Win32
+  | Android
 
 -- | The String representation for a platform, recognised by Node.js.
 toString :: Platform -> String
+toString AIX     = "aix"
 toString Darwin  = "darwin"
 toString FreeBSD = "freebsd"
-toString OpenBSD = "openbsd"
 toString Linux   = "linux"
+toString OpenBSD = "openbsd"
 toString SunOS   = "sunos"
 toString Win32   = "win32"
+toString Android = "android"
 
+-- | Attempt to parse a `Platform` value from a string, in the format returned
+-- | by Node.js' `process.platform`.
 fromString :: String -> Maybe Platform
-fromString "darwin"  = Just Darwin
-fromString "freebsd" = Just FreeBSD
-fromString "openbsd" = Just OpenBSD
-fromString "linux"   = Just Linux
-fromString "sunos"   = Just SunOS
-fromString "win32"   = Just Win32
-fromString _         = Nothing
+fromString "aix"     = AIX
+fromString "darwin"  = Darwin
+fromString "freebsd" = FreeBSD
+fromString "linux"   = Linux
+fromString "openbsd" = OpenBSD
+fromString "sunos"   = SunOS
+fromString "win32"   = Win32
+fromString "android" = Android
 
 instance showPlatform :: Show Platform where
+  show AIX     = "AIX"
   show Darwin  = "Darwin"
   show FreeBSD = "FreeBSD"
-  show OpenBSD = "OpenBSD"
   show Linux   = "Linux"
+  show OpenBSD = "OpenBSD"
   show SunOS   = "SunOS"
   show Win32   = "Win32"
+  show Android = "Android"
 
 derive instance eqPlatform :: Eq Platform
 derive instance ordPlatform :: Ord Platform

--- a/src/Node/Platform.purs
+++ b/src/Node/Platform.purs
@@ -30,14 +30,15 @@ toString Android = "android"
 -- | Attempt to parse a `Platform` value from a string, in the format returned
 -- | by Node.js' `process.platform`.
 fromString :: String -> Maybe Platform
-fromString "aix"     = AIX
-fromString "darwin"  = Darwin
-fromString "freebsd" = FreeBSD
-fromString "linux"   = Linux
-fromString "openbsd" = OpenBSD
-fromString "sunos"   = SunOS
-fromString "win32"   = Win32
-fromString "android" = Android
+fromString "aix"     = Just AIX
+fromString "darwin"  = Just Darwin
+fromString "freebsd" = Just FreeBSD
+fromString "linux"   = Just Linux
+fromString "openbsd" = Just OpenBSD
+fromString "sunos"   = Just SunOS
+fromString "win32"   = Just Win32
+fromString "android" = Just Android
+fromString _         = Nothing
 
 instance showPlatform :: Show Platform where
   show AIX     = "AIX"

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -114,8 +114,11 @@ foreign import setEnv :: forall eff. String -> String -> Eff (process :: PROCESS
 pid :: Pid
 pid = process.pid
 
-platform :: Platform
-platform = unsafePartial $ fromJust $ Platform.fromString process.platform
+platform :: Maybe Platform
+platform = Platform.fromString platformStr
+
+platformStr :: String
+platformStr = process.platform
 
 -- | Cause the process to exit with the supplied integer code. An exit code
 -- | of 0 is normally considered successful, and anything else is considered a

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -29,7 +29,7 @@ import Control.Monad.Eff (Eff, kind Effect)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
 
-import Data.Maybe (Maybe, fromJust)
+import Data.Maybe (Maybe)
 import Data.Posix (Pid)
 import Data.Posix.Signal (Signal)
 import Data.Posix.Signal as Signal
@@ -39,8 +39,6 @@ import Data.StrMap as StrMap
 import Node.Platform (Platform)
 import Node.Platform as Platform
 import Node.Stream (Readable, Writable)
-
-import Partial.Unsafe (unsafePartial)
 
 import Unsafe.Coerce (unsafeCoerce)
 


### PR DESCRIPTION
Rather than assuming that the return value of `process.platform` will be
in the set we recognise, make `Node.Process.platform` return `Nothing`
if the platform is not recognised (for example, if a future version of
Node.js adds more possibilities).

/cc @Thimoteus what do you think about this? I'd quite like to unify this one with the one exported by your `purescript-node-os` (at some point in the future), if that's okay.

This is breaking unfortunately, but I think this really does need fixing properly, and I don't think we can do that without a breaking change.

Looking in https://github.com/purescript/package-sets/blob/master/packages.json, it seems like the only libraries depending on this one in that package set are `node-readline` and `spec`, so IMO we should go ahead and do this. I'll update `node-readline` after this. I'd merge the other PR at the same time, too (i.e. #11).