### PR TITLE
Add mutable references for argv, execArgv and env without ST

### DIFF
--- a/src/Node/Process.js
+++ b/src/Node/Process.js
@@ -65,3 +65,15 @@ exports.exit = function (code) {
     process.exit(code);
   };
 };
+
+exports.copyArray = function (xs) {
+  return function () {
+    return xs.slice();
+  };
+};
+
+exports.copyObject = function (o) {
+  return function () {
+    return Object.assign({}, o);
+  };
+};

--- a/src/Node/Process.js
+++ b/src/Node/Process.js
@@ -72,6 +72,15 @@ exports.copyArray = function (xs) {
   };
 };
 
+exports.replaceArray = function (source) {
+  return function (dest) {
+    return function () {
+      dest.splice(0);
+      Array.prototype.push.apply(dest, source);
+    };
+  };
+};
+
 exports.copyObject = function (o) {
   return function () {
     return Object.assign({}, o);

--- a/src/Node/Process.js
+++ b/src/Node/Process.js
@@ -72,15 +72,6 @@ exports.copyArray = function (xs) {
   };
 };
 
-exports.replaceArray = function (source) {
-  return function (dest) {
-    return function () {
-      dest.splice(0);
-      Array.prototype.push.apply(dest, source);
-    };
-  };
-};
-
 exports.copyObject = function (o) {
   return function () {
     return Object.assign({}, o);

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -115,7 +115,7 @@ getEnv = copyObject process.env
 
 -- | Lookup a particular environment variable.
 lookupEnv :: String -> Effect (Maybe String)
-lookupEnv k = FO.lookup k <$> getEnv
+lookupEnv k = lookupMutableObject k process.env
 
 -- | Set an environment variable.
 foreign import setEnv :: String -> String -> Effect Unit
@@ -176,3 +176,7 @@ foreign import data MutableObject :: Type -> Type
 
 foreign import copyArray :: forall a. MutableArray a -> Effect (Array a)
 foreign import copyObject :: forall a. MutableObject a -> Effect (FO.Object a)
+
+lookupMutableObject :: forall a. String -> MutableObject a -> Effect (Maybe a)
+lookupMutableObject k o =
+  mkEffect \_ -> FO.lookup k (unsafeCoerce o)

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -86,13 +86,11 @@ onSignal sig = onSignalImpl (Signal.toString sig)
 nextTick :: Effect Unit -> Effect Unit
 nextTick callback = mkEffect \_ -> process.nextTick callback
 
--- | Get an array containing the command line arguments. Be aware
--- | that this can change over the course of the program.
+-- | Get an array containing the command line arguments.
 argv :: Effect (Array String)
 argv = copyArray process.argv
 
--- | Node-specific options passed to the `node` executable. Be aware that
--- | this can change over the course of the program.
+-- | Node-specific options passed to the `node` executable.
 execArgv :: Effect (Array String)
 execArgv = copyArray process.execArgv
 

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -6,7 +6,9 @@ module Node.Process
   , onUncaughtException
   , onUnhandledRejection
   , argv
+  , setArgv
   , execArgv
+  , setExecArgv
   , execPath
   , chdir
   , cwd
@@ -90,9 +92,17 @@ nextTick callback = mkEffect \_ -> process.nextTick callback
 argv :: Effect (Array String)
 argv = copyArray process.argv
 
+-- | Overwrite the array containing the command line arguments.
+setArgv :: Array String -> Effect Unit
+setArgv as = replaceArray as process.argv
+
 -- | Node-specific options passed to the `node` executable.
 execArgv :: Effect (Array String)
 execArgv = copyArray process.execArgv
+
+-- | Overwrite the array containing the node-specific options.
+setExecArgv :: Array String -> Effect Unit
+setExecArgv as = replaceArray as process.execArgv
 
 -- | The absolute pathname of the `node` executable that started the
 -- | process.
@@ -173,6 +183,7 @@ foreign import data MutableArray :: Type -> Type
 foreign import data MutableObject :: Type -> Type
 
 foreign import copyArray :: forall a. MutableArray a -> Effect (Array a)
+foreign import replaceArray :: forall a. Array a -> MutableArray a -> Effect Unit
 foreign import copyObject :: forall a. MutableObject a -> Effect (FO.Object a)
 
 lookupMutableObject :: forall a. String -> MutableObject a -> Effect (Maybe a)

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -89,12 +89,12 @@ nextTick callback = mkEffect \_ -> process.nextTick callback
 -- | Get an array containing the command line arguments. Be aware
 -- | that this can change over the course of the program.
 argv :: Effect (Array String)
-argv = mkEffect \_ -> process.argv
+argv = copyArray process.argv
 
 -- | Node-specific options passed to the `node` executable. Be aware that
 -- | this can change over the course of the program.
 execArgv :: Effect (Array String)
-execArgv = mkEffect \_ -> process.execArgv
+execArgv = copyArray process.execArgv
 
 -- | The absolute pathname of the `node` executable that started the
 -- | process.
@@ -111,7 +111,7 @@ cwd = process.cwd
 
 -- | Get a copy of the current environment.
 getEnv :: Effect (FO.Object String)
-getEnv = mkEffect \_ -> process.env
+getEnv = copyObject process.env
 
 -- | Lookup a particular environment variable.
 lookupEnv :: String -> Effect (Maybe String)
@@ -168,3 +168,11 @@ stderrIsTTY = process.stderr.isTTY
 -- | Get the Node.js version.
 version :: String
 version = process.version
+
+-- Utils
+
+foreign import data MutableArray :: Type -> Type
+foreign import data MutableObject :: Type -> Type
+
+foreign import copyArray :: forall a. MutableArray a -> Effect (Array a)
+foreign import copyObject :: forall a. MutableObject a -> Effect (FO.Object a)

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -6,9 +6,7 @@ module Node.Process
   , onUncaughtException
   , onUnhandledRejection
   , argv
-  , setArgv
   , execArgv
-  , setExecArgv
   , execPath
   , chdir
   , cwd
@@ -92,17 +90,9 @@ nextTick callback = mkEffect \_ -> process.nextTick callback
 argv :: Effect (Array String)
 argv = copyArray process.argv
 
--- | Overwrite the array containing the command line arguments.
-setArgv :: Array String -> Effect Unit
-setArgv as = replaceArray as process.argv
-
 -- | Node-specific options passed to the `node` executable.
 execArgv :: Effect (Array String)
 execArgv = copyArray process.execArgv
-
--- | Overwrite the array containing the node-specific options.
-setExecArgv :: Array String -> Effect Unit
-setExecArgv as = replaceArray as process.execArgv
 
 -- | The absolute pathname of the `node` executable that started the
 -- | process.
@@ -183,7 +173,6 @@ foreign import data MutableArray :: Type -> Type
 foreign import data MutableObject :: Type -> Type
 
 foreign import copyArray :: forall a. MutableArray a -> Effect (Array a)
-foreign import replaceArray :: forall a. Array a -> MutableArray a -> Effect Unit
 foreign import copyObject :: forall a. MutableObject a -> Effect (FO.Object a)
 
 lookupMutableObject :: forall a. String -> MutableObject a -> Effect (Maybe a)


### PR DESCRIPTION
Alternative to #25 without the ffi as suggested in https://github.com/purescript-node/purescript-node-process/issues/8#issuecomment-743201372. 

Fixes #8 