### PR TITLE
Add stdinIsTTY (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Breaking changes:
 
 New features:
 
-  - Added `stdinIsTTY` as the counterpart of `process.stdin.isTTY` (#31)
+  - Added `stdinIsTTY` as the counterpart of `process.stdin.isTTY` (#31 by @matoruru)
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+  - Added `stdinIsTTY` as the counterpart of `process.stdin.isTTY` (#31)
+
 Bugfixes:
 
 Other improvements:

--- a/src/Node/Process.purs
+++ b/src/Node/Process.purs
@@ -20,6 +20,7 @@ module Node.Process
   , stdin
   , stdout
   , stderr
+  , stdinIsTTY
   , stdoutIsTTY
   , stderrIsTTY
   , version
@@ -150,6 +151,11 @@ stdout = process.stdout
 -- | `end` will result in an exception being thrown.
 stderr :: Writable ()
 stderr = process.stderr
+
+-- | Check whether the standard input stream appears to be attached to a TTY.
+-- | It is a good idea to check this before processing the input data from stdin.
+stdinIsTTY :: Boolean
+stdinIsTTY = process.stdin.isTTY
 
 -- | Check whether the standard output stream appears to be attached to a TTY.
 -- | It is a good idea to check this before printing ANSI codes to stdout


### PR DESCRIPTION
**Description of the change**

- Closes #30 

I added a function `stdinIsTTY` as the counterpart of `process.stdin.isTTY`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
